### PR TITLE
[FMX Render] Improve draw image performance using default quality

### DIFF
--- a/Source/FMX/FMX.Skia.Canvas.pas
+++ b/Source/FMX/FMX.Skia.Canvas.pas
@@ -2208,10 +2208,10 @@ begin
   else
   begin
     case AQuality of
-      TCanvasQuality.SystemDefault,
+      TCanvasQuality.SystemDefault: TSkSamplingOptions.Medium;
       TCanvasQuality.HighQuality: Result := TSkSamplingOptions.High;
     else
-      Result := TSkSamplingOptions.Create(TSkFilterMode.Nearest, TSkMipmapMode.Nearest);
+      Result := TSkSamplingOptions.Low;
     end;
   end;
 end;


### PR DESCRIPTION
TSkSamplingOptions.High and TSkSamplingOptions.Medium produce a very similar result, but with very different speed.