### PR TITLE
[Controls] Fix TextSettingsInfo.OnChange event

### DIFF
--- a/Source/FMX/FMX.Skia.pas
+++ b/Source/FMX/FMX.Skia.pas
@@ -4601,13 +4601,13 @@ begin
     if FOldTextSettings <> nil then
       FOldTextSettings.Assign(FTextSettings);
   end;
-  if Assigned(FOnChange) then
-    FOnChange(Self);
 end;
 
 procedure TSkTextSettingsInfo.OnCalculatedTextSettings(ASender: TObject);
 begin
   DoCalculatedTextSettings;
+  if Assigned(FOnChange) then
+    FOnChange(Self);
 end;
 
 procedure TSkTextSettingsInfo.OnDefaultChanged(ASender: TObject);
@@ -5266,7 +5266,7 @@ begin
       ResultingTextSettings.Change;
     finally
       ResultingTextSettings.EndUpdate;
-      FTextSettingsInfo.Design := True;//csDesigning in ComponentState;
+      FTextSettingsInfo.Design := csDesigning in ComponentState;
     end;
     if AutoTranslate and not Text.IsEmpty then
     begin
@@ -5310,7 +5310,7 @@ begin
   FAutoSize := True;
   AutoTranslate := True;
   FTextSettingsInfo := TSkTextSettingsInfo.Create(Self, nil);
-  FTextSettingsInfo.Design := True;//csDesigning in ComponentState;
+  FTextSettingsInfo.Design := csDesigning in ComponentState;
   FTextSettingsInfo.OnChange := TextSettingsChanged;
   FWords := TWordsCollection.Create(Self, TWordsItem);
   FWords.OnChange := WordsChange;


### PR DESCRIPTION
- Fire FOnChange when ResultingTextSettings change instead of TextSettings
- in TSkLabel, uncomment `FTextSettingsInfo.Design := csDesigning in ComponentState`